### PR TITLE
Indiscriminately add generated files to 'FileWrites'

### DIFF
--- a/Neteril.ResxStrongifier.targets
+++ b/Neteril.ResxStrongifier.targets
@@ -10,6 +10,7 @@
         BeforeTargets="CoreCompile"
         Condition=" '$(GenerateStringResources)' == 'true' ">
         <ItemGroup>
+            <FileWrites Include="@(ResxCode->'%(GeneratedOutput)')" />
             <Compile Include="@(ResxCode->'%(GeneratedOutput)')" />
         </ItemGroup>
     </Target>


### PR DESCRIPTION
Ensure we add the generated files to the FileWrites itemgroup
so that they are cleaned up as part of the Clean target, and are
not cleaned up by the IncrementalClean target