### PR TITLE
Generate the .designer.cs file too

### DIFF
--- a/GenerateCombinedResources.cs
+++ b/GenerateCombinedResources.cs
@@ -1,0 +1,80 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace NetFx
+{
+	/// <summary>
+	/// Generates a typed class for the given input .resx files.
+	/// </summary>
+	public class GenerateCombinedResources : Task
+	{
+		/// <summary>
+		/// Default class name to use if no TargetClassName metadata is provided
+		/// for the input resx files.
+		/// </summary>
+		public const string DefaultClassName = "Strings";
+
+		/// <summary>
+		/// Language of the containing project.
+		/// </summary>
+		[Required]
+		public string Language { get; set; }
+
+		/// <summary>
+		/// The resource files to process.
+		/// </summary>
+		[Required]
+		public ITaskItem[] ResxFiles { get; set; }
+
+		/// <summary>
+		/// Root namespace for the containing project.
+		/// </summary>
+		[Required]
+		public string RootNamespace { get; set; }
+
+		/// <summary>
+		/// Generated stronly typed code files.
+		/// </summary>
+		[Output]
+		public ITaskItem[] GeneratedFiles { get; set; }
+
+		/// <summary>
+		/// Generates the strong typed resources for the given resx input files.
+		/// </summary>
+		/// <remarks>a remark</remarks>
+		public override bool Execute()
+		{
+			if (Language != "C#")
+			{
+				Log.LogError("Language {0} is not supported yet.", Language);
+				return !Log.HasLoggedErrors;
+			}
+
+			var generatedFiles = new List<ITaskItem>(ResxFiles.Length);
+
+			foreach (var resx in ResxFiles)
+			{
+				bool generateStringResources;
+				if (!bool.TryParse (resx.GetMetadata("GenerateStringResources"), out generateStringResources))
+					generateStringResources = true;
+
+				var stringResources = generateStringResources ? StringResources.Execute(Language, resx, RootNamespace, Log) : "";
+				var designerResources = DesignerResources.Execute(Language, resx, RootNamespace, Log);
+
+				var targetFile = resx.GetMetadata ("GeneratedOutput");
+				Directory.CreateDirectory (Path.GetDirectoryName (targetFile));
+				File.WriteAllText(targetFile, stringResources + System.Environment.NewLine + System.Environment.NewLine + designerResources);
+
+				generatedFiles.Add(new TaskItem(resx) {
+					ItemSpec = targetFile
+				});
+			}
+
+			GeneratedFiles = generatedFiles.ToArray();
+
+			return !Log.HasLoggedErrors;
+		}
+	}
+}

--- a/Neteril.ResxStrongifier.targets
+++ b/Neteril.ResxStrongifier.targets
@@ -1,5 +1,5 @@
 <Project>
-    <UsingTask TaskName="NetFx.StringResources" AssemblyFile="$(MSBuildThisFileDirectory)ResxStrongifier.dll" />
+    <UsingTask TaskName="NetFx.GenerateCombinedResources" AssemblyFile="$(MSBuildThisFileDirectory)ResxStrongifier.dll" />
 
     <PropertyGroup>
         <GenerateStringResources Condition=" '$(GenerateStringResources)' == '' ">true</GenerateStringResources>
@@ -10,49 +10,41 @@
     <!-- If we want our stuff to show up in intellisense we need to use the 'old' mechanism of inserting into     -->
     <!-- the CoreCompileDependsOn list. This should mean we are compatible with VS, VSMac and sdk style projects  -->
     <PropertyGroup>
-        <CoreCompileDependsOn>$(CoreCompileDependsOn);_IncludeStrongifiedSource</CoreCompileDependsOn>
+        <CoreCompileDependsOn>$(CoreCompileDependsOn);GenerateStringResources</CoreCompileDependsOn>
     </PropertyGroup>
 
-    <Target Name="_IncludeStrongifiedSource"
-        DependsOnTargets="StrongifyResx"
-        BeforeTargets="CoreCompile"
-        Condition=" '$(GenerateStringResources)' == 'true' ">
-        <ItemGroup>
-            <FileWrites Include="@(ResxCode->'%(GeneratedOutput)')" />
-            <Compile Include="@(ResxCode->'%(GeneratedOutput)')" />
-        </ItemGroup>
-    </Target>
-
     <Target Name="_IncludeStrongifiedSourceInXamlBuild"
-        DependsOnTargets="StrongifyResx"
-        BeforeTargets="GenerateTemporaryTargetAssembly"
-        Condition=" '$(GenerateStringResources)' == 'true' ">
+        DependsOnTargets="GenerateStringResources"
+        BeforeTargets="GenerateTemporaryTargetAssembly">
         <ItemGroup>
             <_GeneratedCodeFiles Include="@(ResxCode->'%(GeneratedOutput)')" />
         </ItemGroup>
     </Target>
 
     <!-- Compatibility targets with netfx-StringResources -->
-    <Target Name="GenerateStringResources" DependsOnTargets="StrongifyResx" Condition=" '$(GenerateStringResources)' == 'true' " />
-
-    <Target Name="StrongifyResx"
-        DependsOnTargets="_CollectResxCode;_GenerateStringResourcesFiles" Condition=" '$(GenerateStringResources)' == 'true' " />
+    <Target Name="GenerateStringResources" DependsOnTargets="_CollectResxCode;_GenerateCombinedResources">
+        <ItemGroup>
+            <Compile Include="@(ResxCode->'%(GeneratedOutput)')" />
+            <FileWrites Include="@(ResxCode->'%(GeneratedOutput)')" />
+        </ItemGroup>
+    </Target>
 
     <Target Name="_CollectResxCode">
         <ItemGroup>
-            <ResxCode Include="@(EmbeddedResource)" Condition=" %(EmbeddedResource.Generator) == 'ResXFileCodeGenerator' Or %(EmbeddedResource.Generator) == 'PublicResXFileCodeGenerator' ">
-                <GeneratedOutput>$(GeneratedStringResourcesPrefix)%(RelativeDir)%(Filename).Strings$(DefaultLanguageSourceExtension)</GeneratedOutput>
+            <ResxCode Include="@(EmbeddedResource)" Condition=" %(EmbeddedResource.Generator) == 'MSBuild:GenerateStringResources' ">
                 <CanonicalRelativeDir>$([MSBuild]::ValueOrDefault('%(EmbeddedResource.RelativeDir)', '').TrimEnd('\'))</CanonicalRelativeDir>
-                <Public Condition=" %(EmbeddedResource.Generator) == 'PublicResXFileCodeGenerator' ">true</Public>
+                <GenerateStringResources>$(GenerateStringResources)</GenerateStringResources>
+                <GeneratedOutput Condition=" '%(EmbeddedResource.GeneratedOutput)' == '' ">$(GeneratedStringResourcesPrefix)%(RelativeDir)%(Filename).Designer$(DefaultLanguageSourceExtension)</GeneratedOutput>
+                <Public Condition="'%(EmbeddedResource.Public)' == '' ">false</Public>
             </ResxCode>
         </ItemGroup>
     </Target>
 
-    <Target Name="_GenerateStringResourcesFiles"
-        Inputs="@(ResxCode);$(MSBuildThisFileFullPath);$(MSBuildProjectFullPath)"
-        Outputs="@(ResxCode->'%(GeneratedOutput)')">
+    <Target Name="_GenerateCombinedResources"
+        Inputs="%(ResxCode.Identity);$(MSBuildThisFileFullPath);$(MSBuildProjectFullPath)"
+        Outputs="%(ResxCode.GeneratedOutput)">
 
-        <StringResources
+        <GenerateCombinedResources
             RootNamespace="$(RootNamespace)"
             Language="$(Language)"
             ResxFiles="@(ResxCode)" />

--- a/ResxStrongifier.csproj
+++ b/ResxStrongifier.csproj
@@ -15,16 +15,14 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <Content
-            Include="Neteril.ResxStrongifier.props;Neteril.ResxStrongifier.targets"
-            Pack="true"
-            PackagePath="build">
+        <Reference Include="System.Design" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <Content Include="Neteril.ResxStrongifier.props;Neteril.ResxStrongifier.targets" Pack="true" PackagePath="build">
             <Visible>false</Visible>
         </Content>
-        <Content
-            Include="$(OutputPath)/ResxStrongifier.dll;$(OutputPath)/ResxStrongifier.pdb"
-            Pack="true"
-            PackagePath="build">
+        <Content Include="$(OutputPath)/ResxStrongifier.dll;$(OutputPath)/ResxStrongifier.pdb" Pack="true" PackagePath="build">
             <Visible>false</Visible>
         </Content>
     </ItemGroup>


### PR DESCRIPTION
This means when you reference the nuget the only thing you need to do is set the 'Generator' property of the resx file to be 'MSBuild::GenerateStringResources'. After that the .Designer.cs and the .Strings.cs will be generated automatically.
    
We additionally support the 'CustomToolNamespace' and 'Public' properties to control the namespace and public/internal of the generated class.

A full file may look something like this:

```
<EmbeddedResource Update="Files\Resource.resx">
  <CustomToolNamespace>My.Alternate.Namespace</CustomToolNamespace>
  <Generator>MSBuild::GenerateStringResources</Generator>
  <Public>true</Public>
  <TargetClassName>MyCustomClass</TargetClassName>
</EmbeddedResource>
```

This will generate `Resource.Designer.cs` and `Resource.Strings.cs`.

The class in the '.Designer.cs' file will be called 'Resource' and in the '.Strings.cs' file it is overrridden to be 'MyCustomClass'